### PR TITLE
Updated README

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 
-[target]
+[target.xtensa-esp32-none-elf]
 runner = "xtensa-esp32-elf-gdb -q -x openocd.gdb"
 
 

--- a/README.md
+++ b/README.md
@@ -3,38 +3,40 @@
 
 Need help? Join the esp-rs room on matrix, https://matrix.to/#/#esp-rs:matrix.org.
 
-## Building
+## Overview
+ESP32 and ESP8266 chips come with one or two Xtensa CPUs, which (unlike x86 or ARM) are not supported by the official Rust compiler.
 
-### Requirements
+These instructions describe how to build Rust compiler (from [LLVM](https://en.wikipedia.org/wiki/LLVM) and rustc) that supports Xtensa architecture, as well as  how to build and flash blinking LED program to the ESP32.
 
-#### llvm-xtensa
-Please refer to [Espressif's llvm](https://github.com/espressif/llvm-project) project for authoratative instructions.
+## Building Rust compiler
+### System Requirements
+Building Rust compiler is CPU and memory intense process. The compilation can take up to 15 minutes on higher-grade CPUs and even several hours on resource-starved VMs. Besides that, the compilation may fail on systems with less than 6GB of RAM.
 
-    $ git clone https://github.com/espressif/llvm-project
+The required software components and resulting artefacts can take up to 10GB of disk space.
+
+### llvm-xtensa
+If you don't have them already, you'll first have to install `ninja-build` and a C++ compiler (such as `g++`).
+Please refer to [LLVM project](https://llvm.org/docs/GettingStarted.html) for more information.
+
+    $ git clone https://github.com/MabezDev/llvm-project
     $ cd llvm-project/llvm
     $ mkdir build
     $ cd build
-    $ cmake .. -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="Xtensa;X86" -DCMAKE_BUILD_TYPE=Release -G "Ninja"
+    $ cmake .. -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="Xtensa" -DCMAKE_BUILD_TYPE=Release -G "Ninja"
     $ cmake --build .
 
-Calling make with an appropriate number of threads will speed the process considerably.
-
-Many use the guideline `n + 1`, where `n` is the number of processor cores on your machine. For example, for a processor with 4 logical cores:
-    
-    $ make -j5
-
-#### rust-xtensa
+### rust-xtensa
 Please refer to the [rust-xtensa](https://github.com/MabezDev/rust-xtensa) project for authoratative instructions.
 
 Assuming you built llvm in your home directory:
 
     $ git clone https://github.com/MabezDev/rust-xtensa
     $ cd rust-xtensa
-    $ git checkout xtensa-target
     $ ./configure --llvm-root=$HOME/llvm-project/llvm/build
     $ ./x.py build
 
-#### xtensa-esp32-elf toolchain
+## Installing tools
+### xtensa-esp32-elf toolchain
 Instructions can be found [on Espressif's web site](https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html).
 
 Download the archived toolchain file, and extract it to the directory of your choice. Then add the toolchain's bin/ directory to your `$PATH`. For example:
@@ -43,10 +45,12 @@ Download the archived toolchain file, and extract it to the directory of your ch
     $ tar -xzf ~/Downloads/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz -C ~/esp
     $ PATH="$PATH:$HOME/esp/xtensa-esp32-elf/bin"
 
-#### xargo or cargo xbuild
+### xargo or cargo xbuild
+
     $ cargo install xargo
 
 When you install xargo, it may complain that this requires the nightly channel. The fix for this is to switch your rust installation to use the nightly channel as follows:
+
     $ rustup default nightly
     $ rustup update
 
@@ -55,23 +59,31 @@ or
 
     $ cargo install cargo-xbuild
 
-#### esptool
+### esptool
+Esptool is python-based command line tool for flashing ESP32 and ESP8266 chips.
+Full installation instructions are available on [the website](https://github.com/espressif/esptool), but it's usually as straightforward as:
+
     $ pip install esptool
 
+## Blinking LED
 ### Starting a new project
     $ git clone https://github.com/MabezDev/xtensa-rust-quickstart
 
 ### Workflow
-Update `CUSTOM_RUSTC` in `setenv` to point to the version of rust you compiled earlier. Then load the environment variables with `source setenv`.
+Update `CUSTOM_RUSTC` in `setenv` to point to the version of rust you compiled earlier. Then load the environment variables with
+
+    $ source setenv
 
 If you installed `xbuild` instead of `xargo`, you will need to update `flash` and `flash_release` accordingly.
     
-You should now be able to call xargo (or cargo xbuild) to build the project. You can also run the flash script to both build the project, and flash it to the ESP32
+You should now be able to call xargo (or cargo xbuild) to build the project:
+
     $ xargo build
 
 You will need to change the parameter `BLINKY_GPIO` to match your board's LED pin. Unfortunately, this may require adjustments to the chip's IO_MUX peripheral, which will mean consulting the ESP32 Technical Reference Manual. See [this issue](https://github.com/MabezDev/idf2svd/issues/11) for more information.
 
 Then after editing the flash script, you should be able to flash the ESP as follows (you map need to edit the device):
+
     $ ./flash
 
 ## Resources

--- a/setenv
+++ b/setenv
@@ -7,3 +7,4 @@ CUSTOM_RUSTC=/home/mabez/development/rust/xtensa/rust-xtensa
 export RUST_BACKTRACE=1 
 export XARGO_RUST_SRC=$CUSTOM_RUSTC/src 
 export RUSTC=$CUSTOM_RUSTC/build/x86_64-unknown-linux-gnu/stage2/bin/rustc
+export RUSTDOC=$CUSTOM_RUSTC/build/x86_64-unknown-linux-gnu/stage2/bin/rustdoc


### PR DESCRIPTION
- I updated the readme with some information that I had to figure out when I was first installing it: that ESP32 is not ARM based, that you need ninja-build and c++ to install it, that you need quite some resources (I had to resize my VM couple of times)
- Changed LLVM repository to MabezDev one, because it won't break now that Espressif will make LLVM10 default
- Removed the part about -j5, since ninja does that on its own?
- Fixed few commands which were not rendered properly