### PR TITLE
Add instruction for installing cargo-espflash

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Update `CUSTOM_RUSTC` in `setenv` to point to the version of rust you compiled e
 
 ### Flashing
 
-The preffered method of flashing is to use [`cargo-espflash`](https://github.com/icewind1991/espflash). Otherwise you will have to invoke Espressif's `esptool.py` to flash the binaries manually.
+The preffered method of flashing is to use [`cargo-espflash`](https://github.com/icewind1991/espflash), installed with `cargo install cargo-espflash`. Otherwise you will have to invoke Espressif's `esptool.py` to flash the binaries manually.
 
 ```bash
 # Example for the ESP32


### PR DESCRIPTION
Super minor, but add the command to install cargo-espflash. Not complicated, but my first time installing a sub-command for cargo, so didn't really know the relationship between `espflash` and `cargo-espflash`