### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ The preferred method of flashing is to use [`cargo-espflash`](https://github.com
 
 ```bash
 # Example for the ESP32
-$ cargo espflash --chip esp32 --example esp32 --target xtensa-esp32-none-elf --speed 460800 --features="xtensa-lx-rt/lx6,xtensa-lx/lx6,esp32-hal" /dev/ttyUSB0
+$ cargo espflash --chip esp32 --example esp32 --speed 460800 --features="xtensa-lx-rt/lx6,xtensa-lx/lx6,esp32-hal" --tool=[xargo|xbuild|cargo] /dev/ttyUSB0
 ```
 
 ```bash
 # Example for the ESP8266
-$ cargo espflash --chip esp8266 --example esp8266 --target xtensa-esp8266-none-elf --features="xtensa-lx-rt/lx106 xtensa-lx/lx106 esp8266-hal" /dev/ttyUSB0
+$ cargo espflash --chip esp8266 --example esp8266 --features="xtensa-lx-rt/lx106 xtensa-lx/lx106 esp8266-hal" --tool=[xargo|xbuild|cargo] /dev/ttyUSB0
 ```
 
 ## Resources


### PR DESCRIPTION
Remove `--target` argument, which triggers the following error:
```
thread 'main' panicked at 'Unable to parse command-line arguments: unused arguments left: --target', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-espflash-0.1.2/src/main.rs:13:
29    
```