### PR TITLE
Improve Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ git clone https://github.com/MabezDev/rust-xtensa
 $ cd rust-xtensa
 $ CALL "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 $ python3 src/bootstrap/configure.py --experimental-targets=Xtensa
-$ python3 x.py build
+$ python3 x.py build --stage 2
 ```
 
 Before cross-compiling an xtensa target, you must set the following vars either for your system or within your IDE:

--- a/setenv.ps1
+++ b/setenv.ps1
@@ -1,0 +1,10 @@
+# For Windows Powershell
+# Use with ". .\setenv.ps1"
+
+# change this to the directory of where you built rustc for xtensa
+$env:CUSTOM_RUSTC = "G:\rust-xtensa"
+
+$env:RUST_BACKTRACE = "1"
+$env:XARGO_RUST_SRC = "$env:CUSTOM_RUSTC\library" # or /src for an older compiler
+$env:RUSTC = "$env:CUSTOM_RUSTC\build\x86_64-pc-windows-msvc\stage2\bin\rustc"
+$env:RUSTDOC = "$env:CUSTOM_RUSTC\build\x86_64-pc-windows-msvc\stage2\bin\rustdoc"


### PR DESCRIPTION
This PR adds `--stage 2` argument in building instruction for Windows.
This argument is already added for UNIX build instruction (PR #29 ) to fix Issue #26 . However, this fix was not done for Windows instruction.

Additionally, `setenv` script for Windows PowerShell was added.