### PR TITLE
Make esp8266 example unsafe free

### DIFF
--- a/examples/esp8266.rs
+++ b/examples/esp8266.rs
@@ -7,7 +7,7 @@ use esp8266_hal::target::Peripherals;
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { Peripherals::steal() };
+    let dp = Peripherals::take().unwrap();
     let pins = dp.GPIO.split();
     let mut led = pins.gpio2.into_push_pull_output();
     let (mut timer1, _) = dp.TIMER.timers();


### PR DESCRIPTION
I'm a real embedded rookie and it's quite likely I'm messing with something I don't understand,
please disregard this if that is the case.
Replacing the unsafe peripherals access with a safe dito seems to work, at least for the example.