### PR TITLE
Update instructions to make less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Building Rust compiler is CPU and memory intense process. The compilation can ta
 
 The required software components and resulting artefacts can take up to 10GB of disk space.
 
+Make sure you have a working copy of rust already installed. If not, follow the
+[Install Rust](https://www.rust-lang.org/tools/install) instructions.
+
 ## Recommended build method
 
 The fork now uses the xtensa enabled fork as its llvm submodule, so its now possible to build the entire toolchain in a few commands.
@@ -30,7 +33,7 @@ $ ./x.py build --stage 2
 ```
 Before cross-compiling an xtensa target, you must set the following vars, which are set in the setenv script in this project:
 ```
-XARGO_RUST_SRC=/path/to/rust-xtensa/src
+XARGO_RUST_SRC=/path/to/rust-xtensa/library
 RUSTC=/path/to/rust-xtensa/build/x86_64-unknown-linux-gnu/stage2/bin/rustc
 ```
 
@@ -80,18 +83,18 @@ Assuming you built llvm in your home directory:
 ## Installing tools
 ### xtensa-esp32-elf toolchain for esp32 development
 
-Instructions can be found [on Espressif's web site](https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html).
+Download the latest toolchain file from [here](https://github.com/espressif/crosstool-NG/releases).
 
-**Note:** the link provided in espressifs docs is old, for this project to build it requires a new toolchain. Download the latest from [here](https://github.com/espressif/crosstool-NG/releases)
-
-Download the archived toolchain file, and extract it to the directory of your choice. Then add the toolchain's bin/ directory to your `$PATH`. For example:
+Extract it to the directory of your choice. Then add the toolchain's bin/ directory to your `$PATH`. For example:
 
     $ mkdir ~/esp
     $ tar -xzf ~/Downloads/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-8.3.0.tar.gz -C ~/esp
     $ PATH="$PATH:$HOME/esp/xtensa-esp32-elf/bin"
 
+Old instructions can be found [on Espressif's web site](https://docs.espressif.com/projects/esp-idf/en/release-v3.0/get-started/linux-setup.html).
+
 ### xtensa-lx106-elf  toolchain for esp8266 development
-- install the xtensa-lx106-elf toolchain from the [espressif web site](https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/linux-setup.html).
+Install the xtensa-lx106-elf toolchain from the [espressif web site](https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/linux-setup.html).
 
 ```
 $ mkdir ~/esp
@@ -99,8 +102,9 @@ $ tar -xzf ~/Downloads/xtensa-lx106-elf-linux64-1.22.0-100-ge567ec7-5.2.0.tar.gz
 $ PATH="$PATH:$HOME/esp/xtensa-lx106-elf/bin"
 ```
 
-### cargo, xargo or cargo xbuild
+### Cargo Build
 
+<!---
 __NOTE:__ Doesn't work for the ESP32 at the moment: https://github.com/rust-lang/wg-cargo-std-aware/issues/53 
 
 Since the introduction of the `build-std` feature of cargo, it is possible to build `core` without any additional tools.
@@ -111,47 +115,79 @@ As this feature develops it will become the default, for now you can try it by a
 [unstable]
 build-std = ["core", "alloc"]
 ```
+-->
 
-Instead, choose either xargo or cargo xbuild.
+<!---
+Choose either xargo or cargo xbuild.
 
     $ cargo install xargo
 
-When you install xargo, it may complain that this requires the nightly channel. The fix for this is to switch your rust installation to use the nightly channel as follows:
+Note: I could not get this to work.
 
-    $ rustup default nightly
-    $ rustup update
+-->
 
-
-or
+Run
 
     $ cargo install cargo-xbuild
 
 ### esptool
+
+The preferred method of flashing is to use
+[`cargo-espflash`](https://github.com/icewind1991/espflash). Otherwise you will
+have to invoke Espressif's `esptool.py` to flash the binaries manually.
+
+```bash
+    $ cargo install cargo-espflash
+```
+
 Esptool is python-based command line tool for flashing ESP32 and ESP8266 chips.
 Full installation instructions are available on [the website](https://github.com/espressif/esptool), but it's usually as straightforward as:
 
+Python alternative:
+
+```bash
     $ pip install esptool
+```
 
 ## Blinking LED
 ### Starting a new project
+
+```bash
     $ git clone https://github.com/MabezDev/xtensa-rust-quickstart
+```
+
+By default this code blinks using GPIO #2. Edit the code under `examples/esp32.rs` or `examples/esp8266.rs` to change the port as required.
+
+For example:
+
+```
+let mut led = pins.gpio13.into_push_pull_output();
+```
 
 ### Workflow
 Update `CUSTOM_RUSTC` in `setenv` to point to the version of rust you compiled earlier. Then load the environment variables with:
 
     $ source setenv
 
-### Flashing
+### Building
 
-The preferred method of flashing is to use [`cargo-espflash`](https://github.com/icewind1991/espflash), installed with `cargo install cargo-espflash`. Otherwise you will have to invoke Espressif's `esptool.py` to flash the binaries manually.
+Note: Flash operation will also conduct a build.
 
 ```bash
-# Example for the ESP32, remember to use `target = xtensa-esp32-none-elf` inside `.cargo/config`
+cargo xbuild --features="xtensa-lx-rt/lx6,xtensa-lx/lx6,esp32-hal"
+```
+
+### Flashing
+
+Example for the ESP32, remember to use `target = xtensa-esp32-none-elf` inside `.cargo/config`:
+
+```bash
 $ cargo espflash --chip esp32 --example esp32 --speed 460800 --features="xtensa-lx-rt/lx6,xtensa-lx/lx6,esp32-hal" /dev/ttyUSB0
 ```
 
+Example for the ESP8266, remember to use `target = xtensa-esp8266-none-elf` inside `.cargo/config`:
+
 ```bash
-# Example for the ESP8266, remember to use `target = xtensa-esp8266-none-elf` inside `.cargo/config`
 $ cargo espflash --chip esp8266 --example esp8266 --features="xtensa-lx-rt/lx106 xtensa-lx/lx106 esp8266-hal" /dev/ttyUSB0
 ```
 


### PR DESCRIPTION
I found it difficult following the instructions, either because some
steps were missing, or there is too much detail when not required.

A quick start guide should not document "what we would like to see
in the future." Rather it should describe how to do it right now
with existing tools.

This commit fixes some of the problems that I had.